### PR TITLE
Remove HttpsRedirect and exposure of port 443

### DIFF
--- a/Integrator/Integrator/Dockerfile
+++ b/Integrator/Integrator/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
-EXPOSE 443
+#EXPOSE 443
 #ENV ASPNETCORE_ENVIRONMENT "Development"
 #ENV ASPNETCORE_URLS=https://localhost:5001;http://localhost:5000
 #ENV ASPNETCORE_URLS "https://+:443;http://+:80"

--- a/Integrator/Integrator/Startup.cs
+++ b/Integrator/Integrator/Startup.cs
@@ -54,7 +54,7 @@ namespace Integrator
                 app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Integrator v1"));
             }
 
-            app.UseHttpsRedirection();
+            // app.UseHttpsRedirection();
 
             app.UseRouting();
 


### PR DESCRIPTION
This PR removes https redirection and exposure of https port in docker container.

For the tome being I think we should work with http only and make https a priority in the future.